### PR TITLE
with out the 's' it brakes "changeConfig()"

### DIFF
--- a/Providers/GeneratorServiceProvider.php
+++ b/Providers/GeneratorServiceProvider.php
@@ -210,7 +210,7 @@ class GeneratorServiceProvider extends ServiceProvider
             __DIR__.'/../Config/config.php' => config_path('modules/generator.php'),
         ], 'config');
         $this->mergeConfigFrom(
-            __DIR__.'/../Config/config.php', 'module.generator'
+            __DIR__.'/../Config/config.php', 'modules.generator'
         );
     }
 


### PR DESCRIPTION
Generator\Common\GeneratorConfig.php on line 99.

Every `$config->get('modules.generator....')` breakes do no such config exists.

I trying to using your module in the `AdminLTE Templates boilerplate` and generating a module works fine!
but when i try using any other command it breaks.

`php artisan generate:model Book --module=Products`

gives:

```
ErrorException  : array_walk() expects parameter 1 to be array, null given

....Generator\Common\GeneratorConfig.php:121
    117|         // Getting template dir definition from generator
    118|         $templatesDir = $config->get('modules.generator.path.templates_dir');
    119| 
  > 121|         array_walk($modulePaths, function (&$item, $key, $module) {
    122|             $item = str_replace('{Module}', $module, $item);
    124| 
    125|         // Replacing namespaces
```

Do to `$modulePaths = $config->get('modules.generator.path');` not being set.

I'm not sure if it its modules config you are trying to merge with or if you created tour own you need to verify.

Otherwise a relay nice module ! 👍